### PR TITLE
Remove unnecessary start script

### DIFF
--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -1,16 +1,5 @@
 module.exports = {
-  /**
-   * Application configuration section
-   * http://pm2.keymetrics.io/docs/usage/application-declaration/
-   */
   apps: [
-    // First application
-    {
-      name: 'Start API App',
-      script: 'start.js',
-      watch: true
-    },
-    // Second application
     {
       name: 'Index',
       script: 'index.js'


### PR DESCRIPTION
In previous version pm2 started both scripts: start.js and index.js 
So I removed start.js because Foxy extension run start.js via Native Messaging. 